### PR TITLE
Remove libraries duplication from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ bleach==3.1.5
 certifi==2020.6.20
 chardet==3.0.4
 click==7.1.2
-confuse==1.1.0
 coverage==5.1
 cycler==0.10.0
 decorator==4.4.2
@@ -18,9 +17,7 @@ flake8==3.8.3
 htmlmin==0.1.12
 idna==2.9
 ImageHash==4.1.0
-importlib-metadata==1.6.1
 ipykernel==5.3.0
-ipython==7.15.0
 ipython-genutils==0.2.0
 ipywidgets==7.5.1
 jedi==0.17.1


### PR DESCRIPTION
Duplicate libraries were present in the dependency `requirements` file with different versions. We modify it by keeping the newer version dependencies.